### PR TITLE
Add support for synchronouos render functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,26 @@ const { input, messages, isLoading, handleSubmit, onInputChange } = useChat({
 });
 ```
 
+If tool doesn't need to do any async operations as you expect the AI model to return all the required data to render the component, you can use a simple function that returns a component:
+
+```ts
+tools: {
+  joke: {
+    description:
+      "Call this tool with an original joke setup and punchline.",
+    parameters: z.object({
+      setup: z.string(),
+      punchline: z.string(),
+    }),
+    // Render component for joke and pass data also back to the model.
+    render: (data) => ({
+      data,
+      component: <JokeCard data={data} />,
+    }),
+  },
+},
+```
+
 Tools framework within `useChat` is highly extensible. You can define multiple tools to perform various functions based on your chat application's requirements.
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const { input, messages, isLoading, handleSubmit, onInputChange } = useChat({
 });
 ```
 
-If tool doesn't need to do any async operations as you expect the AI model to return all the required data to render the component, you can use a simple function that returns a component:
+If tool doesn't need to do any async operations as you expect the AI model to return all the required data to render the component, you can use a simple function that returns the data and the component:
 
 ```ts
 tools: {

--- a/src/openai/utils.ts
+++ b/src/openai/utils.ts
@@ -46,3 +46,8 @@ export function isReactElement(
 ): message is React.ReactElement {
   return React.isValidElement(message);
 }
+
+export function isAsyncGeneratorFunction(fn: unknown): fn is AsyncGenerator {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator
+  return fn?.constructor?.name === 'AsyncGenerator';
+}


### PR DESCRIPTION
### Description of change

Fixes issue #12.

Why? Sometimes your tool simply displays some info and the requirement for async generators is irrelevant.

#### Discussion:

##### Should we also support synchronouos generators?

I think not as this could lead to tons of unexpected mistakes.

##### Should we also support async render functions without generators?

We have the capability to easily add the support, but maybe we should intentionally leave it out to actively encourage developers to use generators  to show current state of tool processing.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
